### PR TITLE
Set cell to zero if no input left.

### DIFF
--- a/src/Brainfuck.php
+++ b/src/Brainfuck.php
@@ -118,9 +118,7 @@ class Brainfuck
                 $this->output .= chr($this->cells[$this->pointer]);
                 break;
             case ',' :
-                if (isset($this->input[$this->input_pointer])) {
-                    $this->cells[$this->pointer] = ord($this->input[$this->input_pointer]);
-                }
+                $this->cells[$this->pointer] = isset($this->input[$this->input_pointer]) ? ord($this->input[$this->input_pointer]) : 0;
                 $this->input_pointer++;
                 break;
             case '[' :


### PR DESCRIPTION
Most other BF interpreters will set the current cell to zero if they encounter an input operation (,) and there is no input available.